### PR TITLE
Feature/serve oas 3

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,4 +21,4 @@ djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
 drf-writable-nested
-zds-schema==0.12.0
+zds-schema==0.13.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,4 +51,4 @@ six==1.11.0               # via django-markup, djangorestframework-gis, drf-yasg
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.22             # via requests
-zds-schema==0.12.0
+zds-schema==0.13.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -75,4 +75,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.12.0
+zds-schema==0.13.0

--- a/src/zrc/api/schema.py
+++ b/src/zrc/api/schema.py
@@ -1,6 +1,13 @@
+import os
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+import yaml
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
+from rest_framework.response import Response
 from zds_schema.schema import OpenAPISchemaGenerator
 
 info = openapi.Info(
@@ -14,9 +21,39 @@ info = openapi.Info(
     license=openapi.License(name="EUPL 1.2"),
 )
 
-schema_view = get_schema_view(
+DefaultSchemaView = get_schema_view(
     # validators=['flex', 'ssv'],
     generator_class=OpenAPISchemaGenerator,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
+
+
+class SchemaView(DefaultSchemaView):
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+
+        version = request.GET.get('v', '')
+        if not version.startswith('3'):
+            return response
+
+        # serve the staticically included V3 schema
+        SCHEMA_PATH = os.path.join(settings.BASE_DIR, 'src', 'openapi.yaml')
+        with open(SCHEMA_PATH, 'r') as infile:
+            schema = yaml.safe_load(infile)
+
+        # fix the servers
+        for server in schema['servers']:
+            split_url = urlsplit(server['url'])
+            if split_url.netloc:
+                continue
+            server['url'] = request.build_absolute_uri(server['url'])
+
+        # FIXME: fix renderer
+        # see drf_yasg.renderers
+
+        return Response(
+            data=schema,
+            headers={'X-OAS-Version': schema['openapi']}
+        )

--- a/src/zrc/api/schema.py
+++ b/src/zrc/api/schema.py
@@ -1,14 +1,4 @@
-import os
-from urllib.parse import urlsplit
-
-from django.conf import settings
-
-import yaml
 from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework import permissions
-from rest_framework.response import Response
-from zds_schema.schema import OpenAPISchemaGenerator
 
 info = openapi.Info(
     title="Zaakregistratiecomponent (ZRC) API",
@@ -20,40 +10,3 @@ info = openapi.Info(
     ),
     license=openapi.License(name="EUPL 1.2"),
 )
-
-DefaultSchemaView = get_schema_view(
-    # validators=['flex', 'ssv'],
-    generator_class=OpenAPISchemaGenerator,
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-)
-
-
-class SchemaView(DefaultSchemaView):
-
-    def get(self, request, *args, **kwargs):
-        response = super().get(request, *args, **kwargs)
-
-        version = request.GET.get('v', '')
-        if not version.startswith('3'):
-            return response
-
-        # serve the staticically included V3 schema
-        SCHEMA_PATH = os.path.join(settings.BASE_DIR, 'src', 'openapi.yaml')
-        with open(SCHEMA_PATH, 'r') as infile:
-            schema = yaml.safe_load(infile)
-
-        # fix the servers
-        for server in schema['servers']:
-            split_url = urlsplit(server['url'])
-            if split_url.netloc:
-                continue
-            server['url'] = request.build_absolute_uri(server['url'])
-
-        # FIXME: fix renderer
-        # see drf_yasg.renderers
-
-        return Response(
-            data=schema,
-            headers={'X-OAS-Version': schema['openapi']}
-        )

--- a/src/zrc/api/urls.py
+++ b/src/zrc/api/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls import url
 from django.urls import include, path
 
 from zds_schema import routers
+from zds_schema.schema import SchemaView
 
-from .schema import SchemaView
 from .viewsets import (
     KlantContactViewSet, RolViewSet, StatusViewSet, ZaakEigenschapViewSet,
     ZaakInformatieObjectViewSet, ZaakObjectViewSet, ZaakViewSet

--- a/src/zrc/api/urls.py
+++ b/src/zrc/api/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 
 from zds_schema import routers
 
-from .schema import schema_view
+from .schema import SchemaView
 from .viewsets import (
     KlantContactViewSet, RolViewSet, StatusViewSet, ZaakEigenschapViewSet,
     ZaakInformatieObjectViewSet, ZaakObjectViewSet, ZaakViewSet
@@ -27,10 +27,10 @@ urlpatterns = [
 
         # API documentation
         url(r'^schema/openapi(?P<format>\.json|\.yaml)$',
-            schema_view.without_ui(cache_timeout=None),
+            SchemaView.without_ui(cache_timeout=None),
             name='schema-json'),
         url(r'^schema/$',
-            schema_view.with_ui('redoc', cache_timeout=None),
+            SchemaView.with_ui('redoc', cache_timeout=None),
             name='schema-redoc'),
 
         # actual API


### PR DESCRIPTION
Opvragen van het schema via `/api/v1/schema.yaml?v=3` serveert nu direct de OAS 3.0 spec. Zonder deze parameter krijg je nog Swagger 2.0