### PR TITLE
Parametrize more in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,5 +116,12 @@ COPY --from=frontend-build /app/src/zrc/static/fonts /app/src/zrc/static/fonts
 COPY --from=frontend-build /app/src/zrc/static/css /app/src/zrc/static/css
 COPY ./src /app/src
 
+ENV DJANGO_SETTINGS_MODULE=zrc.conf.docker
+
+ARG SECRET_KEY=dummy
+
+# Run collectstatic, so the result is already included in the image
+RUN python src/manage.py collectstatic --noinput
+
 EXPOSE 8000
 CMD ["/start.sh"]

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -1,24 +1,22 @@
 #!/bin/sh
 
-set -e # exit on error
-set -x # echo commands
+set -ex
 
 # Wait for the database container
 # See: https://docs.docker.com/compose/startup-order/
-db_host=${DATABASE_HOST:-db}
-db_user=${DATABASE_USER:-postgres}
-db_password=${DATABASE_PASSWORD}
+db_host=${DB_HOST:-db}
+db_user=${DB_USER:-postgres}
+db_password=${DB_PASSWORD}
+db_port=${DB_PORT:-5432}
 
-until PGPASSWORD=$db_password psql -h "$db_host" -U "$db_user" -c '\q'; do
+uwsgi_port=${UWSGI_PORT:-8000}
+
+until PGPORT=$db_port PGPASSWORD=$db_password psql -h "$db_host" -U "$db_user" -c '\q'; do
   >&2 echo "Waiting for database connection..."
   sleep 1
 done
 
 >&2 echo "Database is up."
-
-# Collect static files
->&2 echo "Collect static files"
-python src/manage.py collectstatic --noinput
 
 # Apply database migrations
 >&2 echo "Apply database migrations"
@@ -26,4 +24,12 @@ python src/manage.py migrate
 
 # Start server
 >&2 echo "Starting server"
-uwsgi --http :8000 --module zrc.wsgi --static-map /static=/app/static --chdir=src
+uwsgi \
+    --http :$uwsgi_port \
+    --module zrc.wsgi \
+    --static-map /static=/app/static \
+    --static-map /media=/app/media  \
+    --chdir src \
+    --processes 2 \
+    --threads 2
+    # processes & threads are needed for concurrency without nginx sitting inbetween

--- a/src/zrc/conf/docker.py
+++ b/src/zrc/conf/docker.py
@@ -2,10 +2,10 @@ import os
 
 from django.core.exceptions import ImproperlyConfigured
 
-os.environ.setdefault('DB_USER', os.getenv('DATABASE_USER', 'postgres'))
-os.environ.setdefault('DB_NAME', os.getenv('DATABASE_NAME', 'postgres'))
-os.environ.setdefault('DB_PASSWORD', os.getenv('DATABASE_PASSWORD', ''))
-os.environ.setdefault('DB_HOST', os.getenv('DATABASE_HOST', 'db'))
+os.environ.setdefault('DB_HOST', 'db')
+os.environ.setdefault('DB_NAME', 'postgres')
+os.environ.setdefault('DB_USER', 'postgres')
+os.environ.setdefault('DB_PASSWORD', '')
 
 from .base import *  # noqa isort:skip
 


### PR DESCRIPTION
The port that uwsgi should bind to can now be specified as well,
allowing the network mode 'host' to be used in docker-compose

This change eventually makes working with `localhost` possible, as mentioned in https://github.com/VNG-Realisatie/gemma-zaken/issues/537