### PR TITLE
Feature/us 331 restrict closed cases

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 0.13.0
+current_version = 0.14.0
 
 [bumpversion:file:README.rst]
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Zaakregistratiecomponent
 ========================
 
-:Version: 0.13.0
+:Version: 0.14.0
 :Source: https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent
 :Keywords: zaken, zaakgericht werken, GEMMA, RGBZ, ZRC
 :PythonVersion: 3.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zrc",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "zrc referentie implementatie API",
   "main": "src/index.js",
   "directories": {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3605,7 +3605,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - (zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     patch:
@@ -3802,7 +3802,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - (zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     delete:

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -4282,7 +4282,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zds.scopes.zaken.bijwerken"
+                            "(zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -4504,7 +4504,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zds.scopes.zaken.bijwerken"
+                            "(zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]

--- a/src/zrc/api/scopes.py
+++ b/src/zrc/api/scopes.py
@@ -61,3 +61,13 @@ SCOPE_ZAKEN_ALLES_VERWIJDEREN = Scope(
 * zaken te verwijderen
 """
 )
+
+
+SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN = Scope(
+    'zds.scopes.zaken.geforceerd-bijwerken',
+    description="""
+**Allows**:
+
+* change attributes of all cases including closed ones    
+"""
+)

--- a/src/zrc/api/tests/test_zaken.py
+++ b/src/zrc/api/tests/test_zaken.py
@@ -422,35 +422,3 @@ class ZakenTests(JWTScopesMixin, APITestCase):
         self.assertEqual(response_data['count'], 2)
         self.assertIsNone(response_data['previous'])
         self.assertIsNone(response_data['next'])
-
-    def test_update_zaak_closed(self):
-        zaak = ZaakFactory.create(
-            einddatum=timezone.now()
-        )
-        url = reverse(zaak)
-
-        token = generate_jwt(scopes=[SCOPE_ZAKEN_BIJWERKEN], zaaktypes=[zaak.zaaktype])
-        self.client.credentials(HTTP_AUTHORIZATION=token)
-
-        response = self.client.patch(url, {
-            'betalingsindicatie': BetalingsIndicatie.nvt,
-        }, **ZAAK_WRITE_KWARGS)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_update_zaak_open(self):
-        zaak = ZaakFactory.create(betalingsindicatie=BetalingsIndicatie.geheel)
-        url = reverse(zaak)
-
-        token = generate_jwt(scopes=[SCOPE_ZAKEN_BIJWERKEN], zaaktypes=[zaak.zaaktype])
-        self.client.credentials(HTTP_AUTHORIZATION=token)
-
-        response = self.client.patch(url, {
-            'betalingsindicatie': BetalingsIndicatie.nvt,
-        }, **ZAAK_WRITE_KWARGS)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-
-        self.assertEqual(response.json()['betalingsindicatie'], BetalingsIndicatie.nvt)
-        zaak.refresh_from_db()
-        self.assertEqual(zaak.betalingsindicatie, BetalingsIndicatie.nvt)

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -27,7 +27,8 @@ from .kanalen import KANAAL_ZAKEN
 from .permissions import ZaaktypePermission
 from .scopes import (
     SCOPE_STATUSSEN_TOEVOEGEN, SCOPE_ZAKEN_ALLES_LEZEN,
-    SCOPE_ZAKEN_ALLES_VERWIJDEREN, SCOPE_ZAKEN_BIJWERKEN, SCOPE_ZAKEN_CREATE
+    SCOPE_ZAKEN_ALLES_VERWIJDEREN, SCOPE_ZAKEN_BIJWERKEN, SCOPE_ZAKEN_CREATE,
+    SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN
 )
 from .serializers import (
     KlantContactSerializer, ResultaatSerializer, RolSerializer,
@@ -158,8 +159,8 @@ class ZaakViewSet(NotificationViewSetMixin,
         'retrieve': SCOPE_ZAKEN_ALLES_LEZEN,
         '_zoek': SCOPE_ZAKEN_ALLES_LEZEN,
         'create': SCOPE_ZAKEN_CREATE,
-        'update': SCOPE_ZAKEN_BIJWERKEN,
-        'partial_update': SCOPE_ZAKEN_BIJWERKEN,
+        'update': SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        'partial_update': SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
         'destroy': SCOPE_ZAKEN_ALLES_VERWIJDEREN,
     }
     notifications_kanaal = KANAAL_ZAKEN
@@ -207,15 +208,19 @@ class ZaakViewSet(NotificationViewSetMixin,
         Perform the update of the Case.
 
         After input validation and before DB persistance we need to check
-        scope-related permissions.
+        scope-related permissions. Only SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN scope
+        allows to alter closed cases
 
-        :raises: PermissionDenied if attempting to alter a closed case
+        :raises: PermissionDenied if attempting to alter a closed case with
+        insufficient permissions
+
         """
         zaak = self.get_object()
         
-        if zaak.einddatum:
-            msg = "Modifying a closed case is forbidden"
-            raise PermissionDenied(detail=msg)
+        if not self.request.jwt_payload.has_scopes(SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN):
+            if zaak.einddatum:
+                msg = "Modifying a closed case with current scope is forbidden"
+                raise PermissionDenied(detail=msg)
         super().perform_create(serializer)
 
 

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -202,6 +202,22 @@ class ZaakViewSet(NotificationViewSetMixin,
     def get_kenmerken(self, data):
         return [{k: data.get(k, '')} for k in settings.NOTIFICATIES_KENMERKEN_NAMES]
 
+    def perform_update(self, serializer):
+        """
+        Perform the update of the Case.
+
+        After input validation and before DB persistance we need to check
+        scope-related permissions.
+
+        :raises: PermissionDenied if attempting to alter a closed case
+        """
+        zaak = self.get_object()
+        
+        if zaak.einddatum:
+            msg = "Modifying a closed case is forbidden"
+            raise PermissionDenied(detail=msg)
+        super().perform_create(serializer)
+
 
 class StatusViewSet(NotificationCreateMixin,
                     CheckQueryParamsMixin,

--- a/src/zrc/tests/test_zaak_alter.py
+++ b/src/zrc/tests/test_zaak_alter.py
@@ -1,0 +1,64 @@
+from django.test import override_settings
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from vng_api_common.tests import JWTScopesMixin, generate_jwt, reverse
+
+from zrc.api.scopes import (
+    SCOPE_ZAKEN_BIJWERKEN, SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN
+)
+from zrc.datamodel.constants import BetalingsIndicatie
+from zrc.datamodel.tests.factories import ZaakFactory
+from zrc.tests.utils import ZAAK_WRITE_KWARGS
+
+
+@override_settings(LINK_FETCHER='vng_api_common.mocks.link_fetcher_200')
+class ApiStrategyTests(JWTScopesMixin, APITestCase):
+
+    def test_update_zaak_open(self):
+        zaak = ZaakFactory.create(betalingsindicatie=BetalingsIndicatie.geheel)
+        url = reverse(zaak)
+
+        token = generate_jwt(scopes=[SCOPE_ZAKEN_BIJWERKEN], zaaktypes=[zaak.zaaktype])
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        response = self.client.patch(url, {
+            'betalingsindicatie': BetalingsIndicatie.nvt,
+        }, **ZAAK_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+        self.assertEqual(response.json()['betalingsindicatie'], BetalingsIndicatie.nvt)
+        zaak.refresh_from_db()
+        self.assertEqual(zaak.betalingsindicatie, BetalingsIndicatie.nvt)
+
+    def test_update_zaak_closed_not_allowed(self):
+        zaak = ZaakFactory.create(
+            einddatum=timezone.now()
+        )
+        url = reverse(zaak)
+
+        token = generate_jwt(scopes=[SCOPE_ZAKEN_BIJWERKEN], zaaktypes=[zaak.zaaktype])
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        response = self.client.patch(url, {
+            'betalingsindicatie': BetalingsIndicatie.nvt,
+        }, **ZAAK_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_zaak_closed_allowed(self):
+        zaak = ZaakFactory.create(
+            einddatum=timezone.now()
+        )
+        url = reverse(zaak)
+
+        token = generate_jwt(scopes=[SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN], zaaktypes=[zaak.zaaktype])
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        response = self.client.patch(url, {
+            'betalingsindicatie': BetalingsIndicatie.nvt,
+        }, **ZAAK_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)


### PR DESCRIPTION
Based on feature/us-801-result-before-end-status (PR - https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/47)

**Changes:**
1. Add new scope 'zds.scopes.zaken.geforceerd-bijwerken' to update and patch all `Zaak` objects
1. Restrict updating closed cases if 'zds.scopes.zaken.geforceerd-bijwerken' is absent
1. Write tests