### PR TITLE
add get_drc_auth to pass to URLvalidator

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,4 +19,4 @@ djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
 drf-writable-nested
-vng-api-common==0.46.2
+vng-api-common==0.47.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,4 +50,4 @@ six==1.11.0               # via django-markup, djangorestframework-gis, drf-yasg
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==0.46.2
+vng-api-common==0.47.1

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -68,7 +68,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==0.46.2
+vng-api-common==0.47.1
 waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30

--- a/src/zrc/api/auth.py
+++ b/src/zrc/api/auth.py
@@ -25,3 +25,12 @@ def get_zrc_auth(url: str) -> dict:
         logger.warning("Could not authenticate for %s", url)
         return {}
     return auth.credentials()
+
+
+def get_drc_auth(url: str) -> dict:
+    logger.info("Authenticating for %s", url)
+    auth = APICredential.get_auth(url)
+    if auth is None:
+        logger.warning("Could not authenticate for %s", url)
+        return {}
+    return auth.credentials()

--- a/src/zrc/api/serializers.py
+++ b/src/zrc/api/serializers.py
@@ -29,7 +29,7 @@ from zrc.datamodel.models import (
 from zrc.datamodel.utils import BrondatumCalculator
 from zrc.utils.exceptions import DetermineProcessEndDateException
 
-from .auth import get_zrc_auth, get_ztc_auth
+from .auth import get_zrc_auth, get_ztc_auth, get_drc_auth
 from .validators import (
     HoofdzaakValidator, NotSelfValidator, RolOccurenceValidator,
     UniekeIdentificatieValidator
@@ -490,7 +490,7 @@ class ZaakInformatieObjectSerializer(NestedHyperlinkedModelSerializer):
             'zaak': {'lookup_field': 'uuid'},
             'informatieobject': {
                 'validators': [
-                    URLValidator(),
+                    URLValidator(get_auth=get_drc_auth),
                     InformatieObjectUniqueValidator('zaak', 'informatieobject'),
                     ObjectInformatieObjectValidator(),
                 ]

--- a/src/zrc/api/serializers.py
+++ b/src/zrc/api/serializers.py
@@ -29,7 +29,7 @@ from zrc.datamodel.models import (
 from zrc.datamodel.utils import BrondatumCalculator
 from zrc.utils.exceptions import DetermineProcessEndDateException
 
-from .auth import get_zrc_auth, get_ztc_auth, get_drc_auth
+from .auth import get_drc_auth, get_zrc_auth, get_ztc_auth
 from .validators import (
     HoofdzaakValidator, NotSelfValidator, RolOccurenceValidator,
     UniekeIdentificatieValidator


### PR DESCRIPTION
Step 2/2 in fixing https://github.com/VNG-Realisatie/gemma-zaken/issues/996

Changes:
1. add `get_drc_auth`, which returns auth and pass it to `URLValidator` in `ZaakInformatieObjectSerializer`