### PR TITLE
turn off url validation for ZaakBesluit

### DIFF
--- a/src/zrc/api/serializers.py
+++ b/src/zrc/api/serializers.py
@@ -642,7 +642,7 @@ class ZaakBesluitSerializer(NestedHyperlinkedModelSerializer):
             'zaak': {'lookup_field': 'uuid'},
             'besluit': {
                 'validators': [
-                    URLValidator(get_auth=get_auth),
+                    # URLValidator(get_auth=get_auth),
                 ]
             }
         }


### PR DESCRIPTION
**Changes:**
1. remove url validation for `besluit` field of `ZaakBesluit` model since this besluit object doesn't exist during requesting ZaakBesluit