### PR TITLE
Issue/nullable read only fields not nullable in oas

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9150,6 +9150,7 @@ components:
           type: string
           format: uri
           readOnly: true
+          nullable: true
         kenmerken:
           description: Lijst van kenmerken. Merk op dat refereren naar gerelateerde
             objecten beter kan via `ZaakObject`.
@@ -9218,6 +9219,7 @@ components:
           type: string
           format: uri
           readOnly: true
+          nullable: true
     GeoWithin:
       title: Zaakgeometrie
       type: object

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -10805,7 +10805,8 @@
                     "description": "Indien geen status bekend is, dan is de waarde 'null'",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "x-nullable": true
                 },
                 "kenmerken": {
                     "description": "Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`.",
@@ -10847,7 +10848,8 @@
                     "description": "URL-referentie naar het RESULTAAT. Indien geen resultaat bekend is, dan is de waarde 'null'",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "x-nullable": true
                 }
             }
         },

--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -130,6 +130,7 @@ class ZaakSerializer(NestedGegevensGroepMixin, NestedCreateMixin, NestedUpdateMi
     status = serializers.HyperlinkedRelatedField(
         source='current_status_uuid',
         read_only=True,
+        allow_null=True,
         view_name='status-detail',
         lookup_url_kwarg='uuid',
         help_text=_("Indien geen status bekend is, dan is de waarde 'null'")
@@ -169,6 +170,7 @@ class ZaakSerializer(NestedGegevensGroepMixin, NestedCreateMixin, NestedUpdateMi
 
     resultaat = serializers.HyperlinkedRelatedField(
         read_only=True,
+        allow_null=True,
         view_name='resultaat-detail',
         lookup_url_kwarg='uuid',
         lookup_field='uuid',


### PR DESCRIPTION
Validation on `Zaak` resources now fails if these fields contain null values.