### PR TITLE
Feature/notificatie documentatie header for new vng api common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,4 +50,4 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.6
+vng-api-common==1.0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,5 +64,5 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.0.6
+vng-api-common==1.0.7
 wrapt==1.11.2             # via astroid

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -65,5 +65,5 @@ text-unidecode==1.2
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.0.6
+vng-api-common==1.0.7
 wrapt==1.11.2

--- a/src/zrc/api/schema.py
+++ b/src/zrc/api/schema.py
@@ -27,6 +27,8 @@ Deze API vereist autorisatie. Je kan de
 [token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te
 genereren.
 
+### Notificaties
+
 {notification_documentation(KANAAL_ZAKEN)}
 
 **Handige links**


### PR DESCRIPTION
because I removed the header `Notificaties` from the util in `vng-api-common` version 1.0.7