### PR TITLE
Feature/update vng api common for klantcontact

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,4 +51,4 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.28
+vng-api-common==1.0.31

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,5 +65,5 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.0.28
+vng-api-common==1.0.31
 wrapt==1.11.2             # via astroid

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -66,5 +66,5 @@ text-unidecode==1.2
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.0.28
+vng-api-common==1.0.31
 wrapt==1.11.2

--- a/src/zrc/api/tests/test_klantcontact.py
+++ b/src/zrc/api/tests/test_klantcontact.py
@@ -31,3 +31,14 @@ class ZaakObjectFilterTestCase(JWTAuthMixin, APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver.com{klantcontact1_url}")
+
+    def test_list_page(self):
+        KlantContactFactory.create_batch(2)
+        url = get_operation_url("klantcontact_list")
+
+        response = self.client.get(url, {"page": 1}, HTTP_HOST="testserver.com")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(len(data), 2)


### PR DESCRIPTION
Issue - https://github.com/open-zaak/open-zaak/issues/141#issuecomment-548723349

Note: ZRC didn't have problems with requesting `page` of `KlantContact` since this resource has a filter in reference implementation. 
But this bug could affect some other resources so the PR is created