### PR TITLE
Add filters to be able to construct a "werkvoorraad" without hurting performance

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,25 +6,25 @@
 #
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
-click==6.7                # via pip-tools
+click==7.1.2              # via pip-tools
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 django-appconf==1.0.2     # via django-axes
-django-axes==4.4.0
-django-choices==1.7.0
-django-cors-middleware==1.3.1
-django-filter==2.0
+django-axes==4.4.0        # via -r requirements/base.in
+django-choices==1.7.0     # via -r requirements/base.in, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/base.in
+django-filter==2.0        # via -r requirements/base.in, vng-api-common
 django-ipware==2.1.0      # via django-axes
-django-markup==1.3
-django-redis==4.10.0
+django-markup==1.3        # via -r requirements/base.in
+django-redis==4.10.0      # via -r requirements/base.in
 django-solo==1.1.3        # via vng-api-common
-django==2.2.8
-djangorestframework-camel-case==0.2.0
-djangorestframework-gis==0.14
-djangorestframework==3.9.4
+django==2.2.8             # via -r requirements/base.in, django-choices, django-filter, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
+djangorestframework-camel-case==0.2.0  # via -r requirements/base.in, vng-api-common
+djangorestframework-gis==0.14  # via -r requirements/base.in
+djangorestframework==3.9.4  # via -r requirements/base.in, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
 drf-nested-routers==0.90.2  # via vng-api-common
-drf-writable-nested==0.4.3
-drf-yasg==1.16.0
+drf-writable-nested==0.4.3  # via -r requirements/base.in
+drf-yasg==1.16.0          # via -r requirements/base.in, vng-api-common
 gemma-zds-client==0.11.0  # via vng-api-common
 idna==2.6                 # via requests
 inflection==0.3.1         # via drf-yasg
@@ -32,17 +32,17 @@ iso-639==0.4.5            # via vng-api-common
 isodate==0.6.0            # via vng-api-common
 itypes==1.1.0             # via coreapi
 jinja2==2.10.1            # via coreschema
-markdown==3.0.1
-markupsafe==1.0           # via jinja2
+markdown==3.0.1           # via -r requirements/base.in
+markupsafe==1.1.1         # via jinja2
 oyaml==0.7                # via vng-api-common
-pip-tools==4.2.0
-psycopg2-binary==2.7.5
+pip-tools==5.1.2          # via -r requirements/base.in
+psycopg2-binary==2.7.5    # via -r requirements/base.in
 pyjwt==1.6.4              # via gemma-zds-client, vng-api-common
-python-dateutil==2.7.3
-python-dotenv==0.8.2
-pytz==2019.1
+python-dateutil==2.7.3    # via -r requirements/base.in
+python-dotenv==0.8.2      # via -r requirements/base.in
+pytz==2019.1              # via -r requirements/base.in, django, django-axes
 pyyaml==5.1.2             # via gemma-zds-client, oyaml, vng-api-common
-raven==6.9.0
+raven==6.9.0              # via -r requirements/base.in
 redis==3.3.6              # via django-redis
 requests==2.21.0          # via coreapi, gemma-zds-client, vng-api-common
 ruamel.yaml==0.15.37      # via drf-yasg
@@ -51,4 +51,7 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.34
+vng-api-common==1.0.34    # via -r requirements/base.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.34    # via -r requirements/base.in
+vng-api-common==1.0.42    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.42    # via -r requirements/base.in
+vng-api-common==1.0.46    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,65 +5,68 @@
 #    pip-compile --no-index --output-file=requirements/dev.txt requirements/base.txt requirements/dev.in requirements/testing.in
 #
 astroid==1.6.6            # via pylint
-certifi==2018.4.16
-chardet==3.0.4
-click==6.7
-coreapi==2.3.3
-coreschema==0.0.4
-coverage==4.5.3
-django-appconf==1.0.2
-django-axes==4.4.0
-django-choices==1.7.0
-django-cors-middleware==1.3.1
-django-debug-toolbar==2.0
-django-filter==2.0.0
-django-ipware==2.1.0
-django-markup==1.3
-django-redis==4.10.0
-django-solo==1.1.3
-django==2.2.8
-djangorestframework-camel-case==0.2.0
-djangorestframework-gis==0.14
-djangorestframework==3.9.4
-drf-nested-routers==0.90.2
-drf-writable-nested==0.4.3
-drf-yasg==1.16.0
-factory-boy==2.12.0
+certifi==2018.4.16        # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
+click==7.1.2              # via -r requirements/base.txt, pip-tools
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
+coverage==4.5.3           # via -r requirements/testing.in
+django-appconf==1.0.2     # via -r requirements/base.txt, django-axes
+django-axes==4.4.0        # via -r requirements/base.txt
+django-choices==1.7.0     # via -r requirements/base.txt, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/base.txt
+django-debug-toolbar==2.0  # via -r requirements/dev.in
+django-filter==2.0.0      # via -r requirements/base.txt, vng-api-common
+django-ipware==2.1.0      # via -r requirements/base.txt, django-axes
+django-markup==1.3        # via -r requirements/base.txt
+django-redis==4.10.0      # via -r requirements/base.txt
+django-solo==1.1.3        # via -r requirements/base.txt, vng-api-common
+django==2.2.8             # via -r requirements/base.txt, django-choices, django-debug-toolbar, django-filter, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
+djangorestframework-camel-case==0.2.0  # via -r requirements/base.txt, vng-api-common
+djangorestframework-gis==0.14  # via -r requirements/base.txt
+djangorestframework==3.9.4  # via -r requirements/base.txt, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
+drf-nested-routers==0.90.2  # via -r requirements/base.txt, vng-api-common
+drf-writable-nested==0.4.3  # via -r requirements/base.txt
+drf-yasg==1.16.0          # via -r requirements/base.txt, vng-api-common
+factory-boy==2.12.0       # via -r requirements/testing.in
 faker==2.0.0              # via factory-boy
-freezegun==0.3.12
-gemma-zds-client==0.11.0
-idna==2.6
-inflection==0.3.1
-iso-639==0.4.5
-isodate==0.6.0
-isort==4.3.21
-itypes==1.1.0
-jinja2==2.10.1
+freezegun==0.3.12         # via -r requirements/testing.in
+gemma-zds-client==0.11.0  # via -r requirements/base.txt, vng-api-common
+idna==2.6                 # via -r requirements/base.txt, requests
+inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
+iso-639==0.4.5            # via -r requirements/base.txt, vng-api-common
+isodate==0.6.0            # via -r requirements/base.txt, vng-api-common
+isort==4.3.21             # via -r requirements/testing.in, pylint
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jinja2==2.10.1            # via -r requirements/base.txt, coreschema
 lazy-object-proxy==1.4.1  # via astroid
-markdown==3.0.1
-markupsafe==1.0
+markdown==3.0.1           # via -r requirements/base.txt
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-oyaml==0.7
-pep8==1.7.1
-pip-tools==4.2.0
-psycopg2-binary==2.7.5
-pyjwt==1.6.4
-pylint==1.9.5
-python-dateutil==2.7.3
-python-dotenv==0.8.2
-pytz==2019.1
-pyyaml==5.1.2
-raven==6.9.0
-redis==3.3.6
-requests-mock==1.6.0
-requests==2.21.0
-ruamel.yaml==0.15.37
-six==1.11.0
-sqlparse==0.3.0
-tblib==1.4.0
+oyaml==0.7                # via -r requirements/base.txt, vng-api-common
+pep8==1.7.1               # via -r requirements/testing.in
+pip-tools==5.1.2          # via -r requirements/base.txt
+psycopg2-binary==2.7.5    # via -r requirements/base.txt
+pyjwt==1.6.4              # via -r requirements/base.txt, gemma-zds-client, vng-api-common
+pylint==1.9.5             # via -r requirements/testing.in
+python-dateutil==2.7.3    # via -r requirements/base.txt, faker, freezegun
+python-dotenv==0.8.2      # via -r requirements/base.txt
+pytz==2019.1              # via -r requirements/base.txt, django, django-axes
+pyyaml==5.1.2             # via -r requirements/base.txt, gemma-zds-client, oyaml, vng-api-common
+raven==6.9.0              # via -r requirements/base.txt
+redis==3.3.6              # via -r requirements/base.txt, django-redis
+requests-mock==1.6.0      # via -r requirements/testing.in
+requests==2.21.0          # via -r requirements/base.txt, coreapi, gemma-zds-client, requests-mock, vng-api-common
+ruamel.yaml==0.15.37      # via -r requirements/base.txt, drf-yasg
+six==1.11.0               # via -r requirements/base.txt, astroid, django-markup, drf-yasg, faker, freezegun, isodate, pip-tools, pylint, python-dateutil, requests-mock
+sqlparse==0.3.0           # via -r requirements/base.txt, django, django-debug-toolbar
+tblib==1.4.0              # via -r requirements/testing.in
 text-unidecode==1.2       # via faker
-unidecode==1.0.22
-uritemplate==3.0.0
-urllib3==1.24.3
-vng-api-common==1.0.34
+unidecode==1.0.22         # via -r requirements/base.txt, vng-api-common
+uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.24.3           # via -r requirements/base.txt, requests
+vng-api-common==1.0.34    # via -r requirements/base.txt
 wrapt==1.11.2             # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,7 +65,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22         # via -r requirements/base.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, requests
-vng-api-common==1.0.34    # via -r requirements/base.txt
+vng-api-common==1.0.42    # via -r requirements/base.txt
 wrapt==1.11.2             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,7 +65,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22         # via -r requirements/base.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, requests
-vng-api-common==1.0.42    # via -r requirements/base.txt
+vng-api-common==1.0.46    # via -r requirements/base.txt
 wrapt==1.11.2             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -66,7 +66,7 @@ text-unidecode==1.2       # via -r requirements/dev.txt, faker
 unidecode==1.0.22         # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, -r requirements/dev.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, -r requirements/dev.txt, requests
-vng-api-common==1.0.34    # via -r requirements/base.txt, -r requirements/dev.txt
+vng-api-common==1.0.42    # via -r requirements/base.txt, -r requirements/dev.txt
 wrapt==1.11.2             # via -r requirements/dev.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -66,7 +66,7 @@ text-unidecode==1.2       # via -r requirements/dev.txt, faker
 unidecode==1.0.22         # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, -r requirements/dev.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, -r requirements/dev.txt, requests
-vng-api-common==1.0.42    # via -r requirements/base.txt, -r requirements/dev.txt
+vng-api-common==1.0.46    # via -r requirements/base.txt, -r requirements/dev.txt
 wrapt==1.11.2             # via -r requirements/dev.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -4,67 +4,70 @@
 #
 #    pip-compile --no-index --output-file=requirements/jenkins.txt requirements/base.txt requirements/dev.txt requirements/jenkins.in
 #
-astroid==1.6.6
-certifi==2018.4.16
-chardet==3.0.4
-click==6.7
-coreapi==2.3.3
-coreschema==0.0.4
-coverage==4.5.3
-django-appconf==1.0.2
-django-axes==4.4.0
-django-choices==1.7.0
-django-cors-middleware==1.3.1
-django-debug-toolbar==2.0
-django-filter==2.0.0
-django-ipware==2.1.0
-django-jenkins==0.110.0
-django-markup==1.3
-django-redis==4.10.0
-django-solo==1.1.3
-django==2.2.8
-djangorestframework-camel-case==0.2.0
-djangorestframework-gis==0.14
-djangorestframework==3.9.4
-drf-nested-routers==0.90.2
-drf-writable-nested==0.4.3
-drf-yasg==1.16.0
-factory-boy==2.12.0
-faker==2.0.0
-freezegun==0.3.12
-gemma-zds-client==0.11.0
-idna==2.6
-inflection==0.3.1
-iso-639==0.4.5
-isodate==0.6.0
-isort==4.3.21
-itypes==1.1.0
-jinja2==2.10.1
-lazy-object-proxy==1.4.1
-markdown==3.0.1
-markupsafe==1.0
-mccabe==0.6.1
-oyaml==0.7
-pep8==1.7.1
-pip-tools==4.2.0
-psycopg2-binary==2.7.5
-pyjwt==1.6.4
-pylint==1.9.5
-python-dateutil==2.7.3
-python-dotenv==0.8.2
-pytz==2019.1
-pyyaml==5.1.2
-raven==6.9.0
-redis==3.3.6
-requests-mock==1.6.0
-requests==2.21.0
-ruamel.yaml==0.15.37
-six==1.11.0
-sqlparse==0.3.0
-tblib==1.4.0
-text-unidecode==1.2
-unidecode==1.0.22
-uritemplate==3.0.0
-urllib3==1.24.3
-vng-api-common==1.0.34
-wrapt==1.11.2
+astroid==1.6.6            # via -r requirements/dev.txt, pylint
+certifi==2018.4.16        # via -r requirements/base.txt, -r requirements/dev.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, -r requirements/dev.txt, requests
+click==7.1.2              # via -r requirements/base.txt, -r requirements/dev.txt, pip-tools
+coreapi==2.3.3            # via -r requirements/base.txt, -r requirements/dev.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, -r requirements/dev.txt, coreapi, drf-yasg
+coverage==4.5.3           # via -r requirements/dev.txt
+django-appconf==1.0.2     # via -r requirements/base.txt, -r requirements/dev.txt, django-axes
+django-axes==4.4.0        # via -r requirements/base.txt, -r requirements/dev.txt
+django-choices==1.7.0     # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/base.txt, -r requirements/dev.txt
+django-debug-toolbar==2.0  # via -r requirements/dev.txt
+django-filter==2.0.0      # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+django-ipware==2.1.0      # via -r requirements/base.txt, -r requirements/dev.txt, django-axes
+django-jenkins==0.110.0   # via -r requirements/jenkins.in
+django-markup==1.3        # via -r requirements/base.txt, -r requirements/dev.txt
+django-redis==4.10.0      # via -r requirements/base.txt, -r requirements/dev.txt
+django-solo==1.1.3        # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+django==2.2.8             # via -r requirements/base.txt, -r requirements/dev.txt, django-choices, django-debug-toolbar, django-filter, django-jenkins, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
+djangorestframework-camel-case==0.2.0  # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+djangorestframework-gis==0.14  # via -r requirements/base.txt, -r requirements/dev.txt
+djangorestframework==3.9.4  # via -r requirements/base.txt, -r requirements/dev.txt, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
+drf-nested-routers==0.90.2  # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+drf-writable-nested==0.4.3  # via -r requirements/base.txt, -r requirements/dev.txt
+drf-yasg==1.16.0          # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+factory-boy==2.12.0       # via -r requirements/dev.txt
+faker==2.0.0              # via -r requirements/dev.txt, factory-boy
+freezegun==0.3.12         # via -r requirements/dev.txt
+gemma-zds-client==0.11.0  # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+idna==2.6                 # via -r requirements/base.txt, -r requirements/dev.txt, requests
+inflection==0.3.1         # via -r requirements/base.txt, -r requirements/dev.txt, drf-yasg
+iso-639==0.4.5            # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+isodate==0.6.0            # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+isort==4.3.21             # via -r requirements/dev.txt, pylint
+itypes==1.1.0             # via -r requirements/base.txt, -r requirements/dev.txt, coreapi
+jinja2==2.10.1            # via -r requirements/base.txt, -r requirements/dev.txt, coreschema
+lazy-object-proxy==1.4.1  # via -r requirements/dev.txt, astroid
+markdown==3.0.1           # via -r requirements/base.txt, -r requirements/dev.txt
+markupsafe==1.1.1         # via -r requirements/base.txt, -r requirements/dev.txt, jinja2
+mccabe==0.6.1             # via -r requirements/dev.txt, pylint
+oyaml==0.7                # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+pep8==1.7.1               # via -r requirements/dev.txt
+pip-tools==5.1.2          # via -r requirements/base.txt, -r requirements/dev.txt
+psycopg2-binary==2.7.5    # via -r requirements/base.txt, -r requirements/dev.txt
+pyjwt==1.6.4              # via -r requirements/base.txt, -r requirements/dev.txt, gemma-zds-client, vng-api-common
+pylint==1.9.5             # via -r requirements/dev.txt
+python-dateutil==2.7.3    # via -r requirements/base.txt, -r requirements/dev.txt, faker, freezegun
+python-dotenv==0.8.2      # via -r requirements/base.txt, -r requirements/dev.txt
+pytz==2019.1              # via -r requirements/base.txt, -r requirements/dev.txt, django, django-axes
+pyyaml==5.1.2             # via -r requirements/base.txt, -r requirements/dev.txt, gemma-zds-client, oyaml, vng-api-common
+raven==6.9.0              # via -r requirements/base.txt, -r requirements/dev.txt
+redis==3.3.6              # via -r requirements/base.txt, -r requirements/dev.txt, django-redis
+requests-mock==1.6.0      # via -r requirements/dev.txt
+requests==2.21.0          # via -r requirements/base.txt, -r requirements/dev.txt, coreapi, gemma-zds-client, requests-mock, vng-api-common
+ruamel.yaml==0.15.37      # via -r requirements/base.txt, -r requirements/dev.txt, drf-yasg
+six==1.11.0               # via -r requirements/base.txt, -r requirements/dev.txt, astroid, django-markup, drf-yasg, faker, freezegun, isodate, pip-tools, pylint, python-dateutil, requests-mock
+sqlparse==0.3.0           # via -r requirements/base.txt, -r requirements/dev.txt, django, django-debug-toolbar
+tblib==1.4.0              # via -r requirements/dev.txt
+text-unidecode==1.2       # via -r requirements/dev.txt, faker
+unidecode==1.0.22         # via -r requirements/base.txt, -r requirements/dev.txt, vng-api-common
+uritemplate==3.0.0        # via -r requirements/base.txt, -r requirements/dev.txt, coreapi, drf-yasg
+urllib3==1.24.3           # via -r requirements/base.txt, -r requirements/dev.txt, requests
+vng-api-common==1.0.34    # via -r requirements/base.txt, -r requirements/dev.txt
+wrapt==1.11.2             # via -r requirements/dev.txt, astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4330,6 +4330,13 @@ paths:
           - confidentieel
           - geheim
           - zeer_geheim
+      - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn
+        in: query
+        description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene
+          bepalingen burgerservicenummer.
+        required: false
+        schema:
+          type: string
       - name: rol__betrokkeneIdentificatie__medewerker__identificatie
         in: query
         description: Een korte unieke aanduiding van de MEDEWERKER.
@@ -9692,6 +9699,12 @@ components:
           - confidentieel
           - geheim
           - zeer_geheim
+        rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn:
+          title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn
+          description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet
+            algemene bepalingen burgerservicenummer.
+          type: string
+          minLength: 1
         rol__betrokkeneIdentificatie__medewerker__identificatie:
           title: Rol  betrokkeneidentificatie  medewerker  identificatie
           description: Een korte unieke aanduiding van de MEDEWERKER.

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4279,6 +4279,22 @@ paths:
         required: false
         schema:
           type: string
+      - name: maximaleVertrouwelijkheidaanduiding
+        in: query
+        description: Zaken met een vertrouwelijkheidaanduiding die beperkter is dan
+          de aangegeven aanduiding worden uit de resultaten gefiltered.
+        required: false
+        schema:
+          type: string
+          enum:
+          - openbaar
+          - beperkt_openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer_geheim
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -9519,6 +9535,12 @@ components:
         startdatum__lte:
           title: Startdatum  lte
           description: De datum waarop met de uitvoering van de zaak is gestart
+          type: string
+          minLength: 1
+        maximaleVertrouwelijkheidaanduiding:
+          title: Maximalevertrouwelijkheidaanduiding
+          description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
+            dan de aangegeven aanduiding worden uit de resultaten gefiltered.
           type: string
           minLength: 1
         ordering:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4330,6 +4330,12 @@ paths:
           - confidentieel
           - geheim
           - zeer_geheim
+      - name: rol__betrokkeneIdentificatie__medewerker__identificatie
+        in: query
+        description: Een korte unieke aanduiding van de MEDEWERKER.
+        required: false
+        schema:
+          type: string
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -9607,9 +9613,28 @@ components:
           minLength: 1
         rol__betrokkeneType:
           title: Rol  betrokkenetype
-          description: Type van de `betrokkene`.
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
           type: string
-          minLength: 1
+          enum:
+          - natuurlijk_persoon
+          - niet_natuurlijk_persoon
+          - vestiging
+          - organisatorische_eenheid
+          - medewerker
         rol__betrokkene:
           title: Rol  betrokkene
           description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
@@ -9617,10 +9642,22 @@ components:
           minLength: 1
         rol__omschrijvingGeneriek:
           title: Rol  omschrijvinggeneriek
-          description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
-            uit het ROLTYPE.
+          description: "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ Adviseur\n* `behandelaar` - Behandelaar\n* `belanghebbende` - Belanghebbende\n\
+            * `beslisser` - Beslisser\n* `initiator` - Initiator\n* `klantcontacter`\
+            \ - Klantcontacter\n* `zaakcoordinator` - Zaakco\xF6rdinator\n* `mede_initiator`\
+            \ - Mede-initiator"
           type: string
-          minLength: 1
+          enum:
+          - adviseur
+          - behandelaar
+          - belanghebbende
+          - beslisser
+          - initiator
+          - klantcontacter
+          - zaakcoordinator
+          - mede_initiator
         maximaleVertrouwelijkheidaanduiding:
           title: Maximalevertrouwelijkheidaanduiding
           description: 'Zaken met een vertrouwelijkheidaanduiding die beperkter is
@@ -9655,6 +9692,11 @@ components:
           - confidentieel
           - geheim
           - zeer_geheim
+        rol__betrokkeneIdentificatie__medewerker__identificatie:
+          title: Rol  betrokkeneidentificatie  medewerker  identificatie
+          description: Een korte unieke aanduiding van de MEDEWERKER.
+          type: string
+          minLength: 1
         ordering:
           title: Ordering
           description: Which field to use when ordering the results.

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4279,6 +4279,41 @@ paths:
         required: false
         schema:
           type: string
+      - name: rol__betrokkeneType
+        in: query
+        description: Type van de `betrokkene`.
+        required: false
+        schema:
+          type: string
+          enum:
+          - natuurlijk_persoon
+          - niet_natuurlijk_persoon
+          - vestiging
+          - organisatorische_eenheid
+          - medewerker
+      - name: rol__betrokkene
+        in: query
+        description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: rol__omschrijvingGeneriek
+        in: query
+        description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+          uit het ROLTYPE.
+        required: false
+        schema:
+          type: string
+          enum:
+          - adviseur
+          - behandelaar
+          - belanghebbende
+          - beslisser
+          - initiator
+          - klantcontacter
+          - zaakcoordinator
+          - mede_initiator
       - name: maximaleVertrouwelijkheidaanduiding
         in: query
         description: Zaken met een vertrouwelijkheidaanduiding die beperkter is dan
@@ -9568,6 +9603,22 @@ components:
         startdatum__lte:
           title: Startdatum  lte
           description: De datum waarop met de uitvoering van de zaak is gestart
+          type: string
+          minLength: 1
+        rol__betrokkeneType:
+          title: Rol  betrokkenetype
+          description: Type van de `betrokkene`.
+          type: string
+          minLength: 1
+        rol__betrokkene:
+          title: Rol  betrokkene
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          type: string
+          minLength: 1
+        rol__omschrijvingGeneriek:
+          title: Rol  omschrijvinggeneriek
+          description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+            uit het ROLTYPE.
           type: string
           minLength: 1
         maximaleVertrouwelijkheidaanduiding:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9468,10 +9468,22 @@ components:
           minLength: 1
         archiefnominatie:
           title: Archiefnominatie
-          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+            overgedragen worden naar een archiefbewaarplaats.
+
+            * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+            worden.'
           type: string
-          minLength: 1
+          enum:
+          - blijvend_bewaren
+          - vernietigen
         archiefnominatie__in:
           title: Archiefnominatie  in
           description: Multiple values may be separated by commas.
@@ -9503,10 +9515,31 @@ components:
           minLength: 1
         archiefstatus:
           title: Archiefstatus
-          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel
+            gearchiveerd.
+
+            * `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar
+            bewaarbaar gemaakt.
+
+            * `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier
+            is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum
+            kan nog niet bepaald worden.
+
+            * `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een
+            archiefbewaarplaats.'
           type: string
-          minLength: 1
+          enum:
+          - nog_te_archiveren
+          - gearchiveerd
+          - gearchiveerd_procestermijn_onbekend
+          - overgedragen
         archiefstatus__in:
           title: Archiefstatus  in
           description: Multiple values may be separated by commas.
@@ -9539,10 +9572,38 @@ components:
           minLength: 1
         maximaleVertrouwelijkheidaanduiding:
           title: Maximalevertrouwelijkheidaanduiding
-          description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
+          description: 'Zaken met een vertrouwelijkheidaanduiding die beperkter is
             dan de aangegeven aanduiding worden uit de resultaten gefiltered.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `openbaar` - Openbaar
+
+            * `beperkt_openbaar` - Beperkt openbaar
+
+            * `intern` - Intern
+
+            * `zaakvertrouwelijk` - Zaakvertrouwelijk
+
+            * `vertrouwelijk` - Vertrouwelijk
+
+            * `confidentieel` - Confidentieel
+
+            * `geheim` - Geheim
+
+            * `zeer_geheim` - Zeer geheim'
           type: string
-          minLength: 1
+          enum:
+          - openbaar
+          - beperkt_openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer_geheim
         ordering:
           title: Ordering
           description: Which field to use when ordering the results.

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -5028,6 +5028,23 @@
                         "type": "string"
                     },
                     {
+                        "name": "maximaleVertrouwelijkheidaanduiding",
+                        "in": "query",
+                        "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "openbaar",
+                            "beperkt_openbaar",
+                            "intern",
+                            "zaakvertrouwelijk",
+                            "vertrouwelijk",
+                            "confidentieel",
+                            "geheim",
+                            "zeer_geheim"
+                        ]
+                    },
+                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -11149,6 +11166,12 @@
                 "startdatum__lte": {
                     "title": "Startdatum  lte",
                     "description": "De datum waarop met de uitvoering van de zaak is gestart",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "maximaleVertrouwelijkheidaanduiding": {
+                    "title": "Maximalevertrouwelijkheidaanduiding",
+                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -5084,6 +5084,13 @@
                         ]
                     },
                     {
+                        "name": "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn",
+                        "in": "query",
+                        "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "rol__betrokkeneIdentificatie__medewerker__identificatie",
                         "in": "query",
                         "description": "Een korte unieke aanduiding van de MEDEWERKER.",
@@ -11270,6 +11277,12 @@
                         "geheim",
                         "zeer_geheim"
                     ]
+                },
+                "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": {
+                    "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn",
+                    "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+                    "type": "string",
+                    "minLength": 1
                 },
                 "rol__betrokkeneIdentificatie__medewerker__identificatie": {
                     "title": "Rol  betrokkeneidentificatie  medewerker  identificatie",

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -5028,6 +5028,45 @@
                         "type": "string"
                     },
                     {
+                        "name": "rol__betrokkeneType",
+                        "in": "query",
+                        "description": "Type van de `betrokkene`.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "natuurlijk_persoon",
+                            "niet_natuurlijk_persoon",
+                            "vestiging",
+                            "organisatorische_eenheid",
+                            "medewerker"
+                        ]
+                    },
+                    {
+                        "name": "rol__betrokkene",
+                        "in": "query",
+                        "description": "URL-referentie naar een betrokkene gerelateerd aan de ZAAK.",
+                        "required": false,
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    {
+                        "name": "rol__omschrijvingGeneriek",
+                        "in": "query",
+                        "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "adviseur",
+                            "behandelaar",
+                            "belanghebbende",
+                            "beslisser",
+                            "initiator",
+                            "klantcontacter",
+                            "zaakcoordinator",
+                            "mede_initiator"
+                        ]
+                    },
+                    {
                         "name": "maximaleVertrouwelijkheidaanduiding",
                         "in": "query",
                         "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
@@ -11174,6 +11213,24 @@
                 "startdatum__lte": {
                     "title": "Startdatum  lte",
                     "description": "De datum waarop met de uitvoering van de zaak is gestart",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneType": {
+                    "title": "Rol  betrokkenetype",
+                    "description": "Type van de `betrokkene`.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkene": {
+                    "title": "Rol  betrokkene",
+                    "description": "URL-referentie naar een betrokkene gerelateerd aan de ZAAK.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__omschrijvingGeneriek": {
+                    "title": "Rol  omschrijvinggeneriek",
+                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -5084,6 +5084,13 @@
                         ]
                     },
                     {
+                        "name": "rol__betrokkeneIdentificatie__medewerker__identificatie",
+                        "in": "query",
+                        "description": "Een korte unieke aanduiding van de MEDEWERKER.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -11218,9 +11225,15 @@
                 },
                 "rol__betrokkeneType": {
                     "title": "Rol  betrokkenetype",
-                    "description": "Type van de `betrokkene`.",
+                    "description": "Type van de `betrokkene`.\n\nUitleg bij mogelijke waarden:\n\n* `natuurlijk_persoon` - Natuurlijk persoon\n* `niet_natuurlijk_persoon` - Niet-natuurlijk persoon\n* `vestiging` - Vestiging\n* `organisatorische_eenheid` - Organisatorische eenheid\n* `medewerker` - Medewerker",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "natuurlijk_persoon",
+                        "niet_natuurlijk_persoon",
+                        "vestiging",
+                        "organisatorische_eenheid",
+                        "medewerker"
+                    ]
                 },
                 "rol__betrokkene": {
                     "title": "Rol  betrokkene",
@@ -11230,9 +11243,18 @@
                 },
                 "rol__omschrijvingGeneriek": {
                     "title": "Rol  omschrijvinggeneriek",
-                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
+                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` - Adviseur\n* `behandelaar` - Behandelaar\n* `belanghebbende` - Belanghebbende\n* `beslisser` - Beslisser\n* `initiator` - Initiator\n* `klantcontacter` - Klantcontacter\n* `zaakcoordinator` - Zaakco\u00f6rdinator\n* `mede_initiator` - Mede-initiator",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "adviseur",
+                        "behandelaar",
+                        "belanghebbende",
+                        "beslisser",
+                        "initiator",
+                        "klantcontacter",
+                        "zaakcoordinator",
+                        "mede_initiator"
+                    ]
                 },
                 "maximaleVertrouwelijkheidaanduiding": {
                     "title": "Maximalevertrouwelijkheidaanduiding",
@@ -11248,6 +11270,12 @@
                         "geheim",
                         "zeer_geheim"
                     ]
+                },
+                "rol__betrokkeneIdentificatie__medewerker__identificatie": {
+                    "title": "Rol  betrokkeneidentificatie  medewerker  identificatie",
+                    "description": "Een korte unieke aanduiding van de MEDEWERKER.",
+                    "type": "string",
+                    "minLength": 1
                 },
                 "ordering": {
                     "title": "Ordering",

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -11099,9 +11099,12 @@
                 },
                 "archiefnominatie": {
                     "title": "Archiefnominatie",
-                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
+                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.\n\nUitleg bij mogelijke waarden:\n\n* `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.\n* `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "blijvend_bewaren",
+                        "vernietigen"
+                    ]
                 },
                 "archiefnominatie__in": {
                     "title": "Archiefnominatie  in",
@@ -11129,9 +11132,14 @@
                 },
                 "archiefstatus": {
                     "title": "Archiefstatus",
-                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
+                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.\n\nUitleg bij mogelijke waarden:\n\n* `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel gearchiveerd.\n* `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar bewaarbaar gemaakt.\n* `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum kan nog niet bepaald worden.\n* `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een archiefbewaarplaats.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "nog_te_archiveren",
+                        "gearchiveerd",
+                        "gearchiveerd_procestermijn_onbekend",
+                        "overgedragen"
+                    ]
                 },
                 "archiefstatus__in": {
                     "title": "Archiefstatus  in",
@@ -11171,9 +11179,18 @@
                 },
                 "maximaleVertrouwelijkheidaanduiding": {
                     "title": "Maximalevertrouwelijkheidaanduiding",
-                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
+                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.\n\nUitleg bij mogelijke waarden:\n\n* `openbaar` - Openbaar\n* `beperkt_openbaar` - Beperkt openbaar\n* `intern` - Intern\n* `zaakvertrouwelijk` - Zaakvertrouwelijk\n* `vertrouwelijk` - Vertrouwelijk\n* `confidentieel` - Confidentieel\n* `geheim` - Geheim\n* `zeer_geheim` - Zeer geheim",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "openbaar",
+                        "beperkt_openbaar",
+                        "intern",
+                        "zaakvertrouwelijk",
+                        "vertrouwelijk",
+                        "confidentieel",
+                        "geheim",
+                        "zeer_geheim"
+                    ]
                 },
                 "ordering": {
                     "title": "Ordering",

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -54,6 +54,11 @@ class ZaakFilter(FilterSet):
             "archiefactiedatum": ["exact", "lt", "gt"],
             "archiefstatus": ["exact", "in"],
             "startdatum": ["exact", "gt", "gte", "lt", "lte"],
+
+            # filters for werkvoorraad
+            "rol__betrokkene_type": ["exact"],
+            "rol__betrokkene": ["exact"],
+            "rol__omschrijving_generiek": ["exact"],
         }
 
 

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -44,6 +44,10 @@ class ZaakFilter(FilterSet):
         ),
     )
 
+    rol__betrokkene_identificatie__natuurlijk_persoon__inp_bsn = filters.CharFilter(
+        field_name="rol__natuurlijkpersoon__inp_bsn",
+        help_text=get_help_text("datamodel.NatuurlijkPersoon", "inp_bsn"),
+    )
     rol__betrokkene_identificatie__medewerker__identificatie = filters.CharFilter(
         field_name="rol__medewerker__identificatie",
         help_text=get_help_text("datamodel.Medewerker", "identificatie"),

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -1,4 +1,5 @@
 from django_filters import filters
+from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
 
@@ -13,7 +14,32 @@ from zrc.datamodel.models import (
 )
 
 
+class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("choices", VertrouwelijkheidsAanduiding.choices)
+        kwargs.setdefault("lookup_expr", "lte")
+        super().__init__(*args, **kwargs)
+
+        # rewrite the field_name correctly
+        self._field_name = self.field_name
+        self.field_name = f"_{self._field_name}_order"
+
+    def filter(self, qs, value):
+        if value in filters.EMPTY_VALUES:
+            return qs
+        order_expression = VertrouwelijkheidsAanduiding.get_order_expression(
+            self._field_name
+        )
+        qs = qs.annotate(**{self.field_name: order_expression})
+        numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
+        return super().filter(qs, numeric_value)
+
+
 class ZaakFilter(FilterSet):
+    maximale_vertrouwelijkheidaanduiding = MaximaleVertrouwelijkheidaanduidingFilter(
+        field_name="vertrouwelijkheidaanduiding",
+    )
+
     class Meta:
         model = Zaak
         fields = {

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -44,6 +44,11 @@ class ZaakFilter(FilterSet):
         ),
     )
 
+    rol__betrokkene_identificatie__medewerker__identificatie = filters.CharFilter(
+        field_name="rol__medewerker__identificatie",
+        help_text=get_help_text("datamodel.Medewerker", "identificatie"),
+    )
+
     class Meta:
         model = Zaak
         fields = {
@@ -54,7 +59,6 @@ class ZaakFilter(FilterSet):
             "archiefactiedatum": ["exact", "lt", "gt"],
             "archiefstatus": ["exact", "in"],
             "startdatum": ["exact", "gt", "gte", "lt", "lte"],
-
             # filters for werkvoorraad
             "rol__betrokkene_type": ["exact"],
             "rol__betrokkene": ["exact"],

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -38,6 +38,10 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
 class ZaakFilter(FilterSet):
     maximale_vertrouwelijkheidaanduiding = MaximaleVertrouwelijkheidaanduidingFilter(
         field_name="vertrouwelijkheidaanduiding",
+        help_text=(
+            "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de "
+            "aangegeven aanduiding worden uit de resultaten gefiltered."
+        ),
     )
 
     class Meta:

--- a/src/zrc/api/tests/test_zaken.py
+++ b/src/zrc/api/tests/test_zaken.py
@@ -573,6 +573,35 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertIn(f"http://testserver{eigenschap1_url}", eigenschappen)
         self.assertIn(f"http://testserver{eigenschap2_url}", eigenschappen)
 
+    def test_filter_max_vertrouwelijkheidaanduiding(self):
+        zaak1 = ZaakFactory.create(
+            zaaktype=ZAAKTYPE,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+        )
+        zaak2 = ZaakFactory.create(
+            zaaktype=ZAAKTYPE,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.geheim,
+        )
+
+        url = reverse(Zaak)
+
+        response = self.client.get(
+            url,
+            {
+                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.zaakvertrouwelijk
+            },
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["url"], f"http://testserver{reverse(zaak1)}",
+        )
+        self.assertNotEqual(
+            response.data["results"][0]["url"], f"http://testserver{reverse(zaak2)}",
+        )
+
 
 class ZaakArchivingTests(JWTAuthMixin, APITestCase):
 


### PR DESCRIPTION
Continues on #144

---

One recurring criticism of the Zaken API is that it's not possible to retrieve a collection of Zaken for a given person/role without incurring an incredible performance penalty. The math is done in https://github.com/VNG-Realisatie/gemma-zaken/issues/1599 by @rubenvdlinde

This prevents common queries, such as:

* show all zaken where "Medewerker X" is behandelaar
* show all zaken initiated by citizen with BSN "xyz"

This patch adds filters to the standard to make this possible. They all apply to the `/api/v1/zaken` endpoint and are optional.

* `rol__betrokkene`: filters zaken where the `betrokkene` identified by the provided URL (value of the search parameter) has a rol in the zaak
* `rol__betrokkeneType`: filters zaken where a rol of the specified `betrokkeneType` (NP, Medewerker, NNP, vestiging, OE) is present for each zaak.
* `rol__omschrijvingGeneriek`: filter on the kind of rol the betrokkene has in the zaak: initiator, behandelaar...
* `rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn`: return zaken for a particular citizen with a given BSN. Exists because there currently is no Natuurlijke Personen API, so filtering on the `rol__betrokkene` parameter is not possible yet. This is crucial for "Mijn Gemeente" apps that wish to display zaken for the logged in user.
* `rol__betrokkeneIdentificatie__medewerker__identificatie`: this is crucial for organizations that do not have an API/registration yet for medewerkers with a URL, but want to retrieve a werkvoorraad, similar to the above case.

- [x] Tests validating behaviour
- [x] Feature implementation
- [x] Documentation