### PR TITLE
Issue/zio specific document version

### DIFF
--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -64,6 +64,7 @@ from ..validators import (
     CorrectZaaktypeValidator,
     DateNotInFutureValidator,
     HoofdzaakValidator,
+    LatestVersionValidator,
     NotSelfValidator,
     RolOccurenceValidator,
     UniekeIdentificatieValidator,
@@ -775,6 +776,7 @@ class ZaakInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
             "uuid": {"read_only": True},
             "informatieobject": {
                 "validators": [
+                    LatestVersionValidator(),
                     ResourceValidator(
                         "EnkelvoudigInformatieObject",
                         settings.DRC_API_SPEC,

--- a/src/zrc/api/tests/test_zaakinformatieobjecten.py
+++ b/src/zrc/api/tests/test_zaakinformatieobjecten.py
@@ -155,6 +155,36 @@ class ZaakInformatieObjectAPITests(
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "unique")
 
+    @freeze_time("2018-09-19T12:25:19+0200")
+    @override_settings(ZDS_CLIENT_CLASS="vng_api_common.mocks.MockClient")
+    @patch("vng_api_common.validators.fetcher")
+    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    def test_create_with_specific_informatieobject_version_fails(self, *mocks):
+        zaak = ZaakFactory.create(zaaktype=ZAAKTYPE)
+        zaak_url = reverse("zaak-detail", kwargs={"version": "1", "uuid": zaak.uuid})
+
+        titel = "some titel"
+        beschrijving = "some beschrijving"
+        content = {
+            "informatieobject": f"{INFORMATIEOBJECT}?versie=1",
+            "zaak": f"http://testserver{zaak_url}",
+            "titel": titel,
+            "beschrijving": beschrijving,
+            "aardRelatieWeergave": "bla",  # Should be ignored by the API
+        }
+
+        # Send to the API
+        with mock_client(RESPONSES):
+            response = self.client.post(self.list_url, content)
+
+        # Test response
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+        error = get_validation_errors(response, "informatieobject")
+        self.assertEqual(error["code"], "not-latest-version")
+
     @freeze_time("2018-09-20 12:00:00")
     def test_read_zaak(self):
         zio = ZaakInformatieObjectFactory.create(informatieobject=INFORMATIEOBJECT)

--- a/src/zrc/api/validators.py
+++ b/src/zrc/api/validators.py
@@ -1,4 +1,5 @@
 from datetime import date
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
 from django.db import models
@@ -164,4 +165,17 @@ class DateNotInFutureValidator:
             now = now.date()
 
         if value > now:
+            raise serializers.ValidationError(self.message, code=self.code)
+
+
+class LatestVersionValidator:
+    code = "not-latest-version"
+    message = _(
+        "Er mag geen specifieke versie van een informatieobject worden opgegeven"
+    )
+
+    def __call__(self, value):
+        url = urlparse(value)
+
+        if "versie" in parse_qs(url.query):
             raise serializers.ValidationError(self.message, code=self.code)


### PR DESCRIPTION
issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1270

* Added a validator that checks if no `versie` query parameters are present on `ZIO.informatieobject`